### PR TITLE
Implement SpiderFR dataset loader

### DIFF
--- a/src/agent/SpiderFRDataset.py
+++ b/src/agent/SpiderFRDataset.py
@@ -1,85 +1,67 @@
-import datasets
+import json
+import os
 from torch.utils.data import Dataset
 from transformers import PreTrainedTokenizerBase
 
 class SpiderFRDataset(Dataset):
-    """
-    Dataset handler for Marchanjo/spider-fr dataset, formatted for causal LM QLoRA training.
-    Concatenates question and SQL query, masking question tokens in labels for causal loss.
-    """
-    def __init__(self,
-                 hf_dataset_name: str = "Marchanjo/spider-fr",
-                 split: str = "train",
-                 tokenizer: PreTrainedTokenizerBase = None,
-                 max_length: int = 512,
-                 prompt_template: str = "{question}\nSQL:",
-                 eos_token: str = None):
-        assert tokenizer is not None, "A tokenizer must be provided"
+    """Dataset for the Spider-FR JSON files used in training."""
+
+    SPLIT_FILES = {
+        "train": "train_spider.json",
+        "train_others": "train_others.json",
+        "dev": "dev_spider.json",
+    }
+
+    def __init__(
+        self,
+        data_dir: str,
+        split: str,
+        tokenizer: PreTrainedTokenizerBase,
+        question_max_length: int = 128,
+        query_max_length: int = 256,
+    ):
+        if tokenizer is None:
+            raise ValueError("tokenizer must be provided")
+        if split not in self.SPLIT_FILES:
+            raise ValueError(f"Unsupported split '{split}'")
+
         self.tokenizer = tokenizer
-        self.max_length = max_length
-        self.prompt_template = prompt_template
-        # Use provided EOS or tokenizer default
-        self.eos_token = eos_token if eos_token is not None else (tokenizer.eos_token or "")
+        self.question_max_length = question_max_length
+        self.query_max_length = query_max_length
 
-        # Load Hugging Face dataset
-        self.dataset = datasets.load_dataset(hf_dataset_name, split=split)
+        file_path = os.path.join(data_dir, self.SPLIT_FILES[split])
+        with open(file_path, "r", encoding="utf-8") as f:
+            raw_records = json.load(f)
 
-        # Tokenize and prepare
-        self.dataset = self.dataset.map(
-            self._tokenize_example,
-            remove_columns=self.dataset.column_names,
-        )
+        questions = [rec.get("question", "") for rec in raw_records]
+        queries = [rec.get("query", "") for rec in raw_records]
 
-        # Set PyTorch format
-        self.dataset.set_format(type="torch", columns=["input_ids", "attention_mask", "labels"])
-
-    def _tokenize_example(self, example):
-        # Extract fields
-        question = example.get("question", "")
-        query = example.get("query", "")
-
-        # Build the prompt and full sequence
-        prompt_text = self.prompt_template.format(question=question)
-        full_text = prompt_text + " " + query + self.eos_token
-
-        # Tokenize full sequence
-        encoding = self.tokenizer(
-            full_text,
-            truncation=True,
+        enc_questions = tokenizer(
+            questions,
             padding="max_length",
-            max_length=self.max_length,
-        )
-        input_ids = encoding["input_ids"]
-        attention_mask = encoding["attention_mask"]
-
-        # Determine prompt token length (tokens not equal to pad)
-        prompt_encoding = self.tokenizer(
-            prompt_text,
             truncation=True,
+            max_length=question_max_length,
+            return_tensors="pt",
+        )
+
+        enc_queries = tokenizer(
+            queries,
             padding="max_length",
-            max_length=self.max_length,
-        )
-        # Count non-pad tokens in prompt to mask labels
-        prompt_token_count = sum(
-            1 for tid in prompt_encoding["input_ids"] if tid != self.tokenizer.pad_token_id
+            truncation=True,
+            max_length=query_max_length,
+            return_tensors="pt",
         )
 
-        # Create labels: mask prompt tokens with -100
-        labels = input_ids.copy()
-        labels[:prompt_token_count] = [-100] * prompt_token_count
-
-        return {"input_ids": input_ids,
-                "attention_mask": attention_mask,
-                "labels": labels}
+        self.input_ids = enc_questions.input_ids
+        self.attention_mask = enc_questions.attention_mask
+        self.labels = enc_queries.input_ids
 
     def __len__(self):
-        return len(self.dataset)
+        return self.input_ids.size(0)
 
     def __getitem__(self, idx):
-        return self.dataset[idx]
-
-    def get_dataset(self):
-        """
-        Returns the internal Hugging Face dataset formatted for PyTorch.
-        """
-        return self.dataset
+        return {
+            "input_ids": self.input_ids[idx],
+            "attention_mask": self.attention_mask[idx],
+            "labels": self.labels[idx],
+        }

--- a/src/agent/train.py
+++ b/src/agent/train.py
@@ -1,10 +1,10 @@
 from transformers import AutoModelForCausalLM, AutoTokenizer, TrainingArguments, Trainer
 from peft import prepare_model_for_kbit_training, LoraConfig, get_peft_model
-from datasets import load_dataset
 import torch
 
+from .SpiderFRDataset import SpiderFRDataset
+
 model_name = "meta-llama/Llama-2-7b-hf"  # Change as needed
-dataset_name = "yelp_review_full"  # Example dataset
 
 # Load model and tokenizer
 tokenizer = AutoTokenizer.from_pretrained(model_name, use_fast=True)
@@ -33,10 +33,11 @@ lora_config = LoraConfig(
 model = get_peft_model(model, lora_config)
 
 # Load and tokenize dataset
-dataset = load_dataset(dataset_name)
-def tokenize_function(example):
-    return tokenizer(example["text"], truncation=True, padding="max_length", max_length=512)
-tokenized_dataset = dataset.map(tokenize_function, batched=True)
+train_dataset = SpiderFRDataset(
+    data_dir="./data/spider-fr",
+    split="train",
+    tokenizer=tokenizer,
+)
 
 # Training
 training_args = TrainingArguments(
@@ -54,7 +55,7 @@ training_args = TrainingArguments(
 trainer = Trainer(
     model=model,
     args=training_args,
-    train_dataset=tokenized_dataset["train"],
+    train_dataset=train_dataset,
     tokenizer=tokenizer,
 )
 


### PR DESCRIPTION
## Summary
- create a new `SpiderFRDataset` that tokenizes the local Spider‑FR JSON files
- integrate the dataset into `train.py` for training

## Testing
- `python -m py_compile src/agent/SpiderFRDataset.py src/agent/train.py`

------
https://chatgpt.com/codex/tasks/task_e_6886c6c398788333a89bb25d1c95ac62