### PR TITLE
Add Simple NL2SQL agent

### DIFF
--- a/src/agent/SimpleAgent.py
+++ b/src/agent/SimpleAgent.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+import torch
+from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+from .PromptGenerator import generate_sql_prompt
+
+class SimpleAgent:
+    """Lightweight NL2SQL agent using an off-the-shelf model.
+
+    The agent loads a multilingual instruction-tuned model and uses it
+    directly to generate SQL queries from natural language without any
+    additional fine-tuning. Questions may be written in either French or
+    English.
+    """
+
+    def __init__(self, model_name: str = "google/flan-t5-base", device: str | None = None) -> None:
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.model = AutoModelForSeq2SeqLM.from_pretrained(model_name)
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        self.model.to(self.device)
+
+    def generate(self, schema: dict, question: str, db_type: str = "SQLite") -> str:
+        """Generate a SQL query for *question* given the database *schema*."""
+        prompt = generate_sql_prompt(schema, question, db_type)
+        inputs = self.tokenizer(prompt, return_tensors="pt").to(self.device)
+        outputs = self.model.generate(
+            **inputs,
+            max_new_tokens=150,
+            do_sample=False,
+        )
+        return self.tokenizer.decode(outputs[0], skip_special_tokens=True).strip()

--- a/src/agent/__init__.py
+++ b/src/agent/__init__.py
@@ -1,0 +1,2 @@
+from .PromptGenerator import generate_sql_prompt
+from .SimpleAgent import SimpleAgent

--- a/src/main.py
+++ b/src/main.py
@@ -7,6 +7,7 @@ import sqlite3
 from DBManager import DBManager
 from DialogModule import DialogModule
 from agent.PromptGenerator import generate_sql_prompt
+from agent.SimpleAgent import SimpleAgent
 
 DB_PATH = "database/sqlite/employee_db.sqlite"
 # File storing past user questions for the DialogModule
@@ -78,11 +79,20 @@ def main() -> None:
 
     prompt = generate_sql_prompt(schema_for_prompt, question, db_type="sqlite")
 
-    # TODO: integrate the actual LLM call here
+    agent = SimpleAgent()
     print("\n[LLM PROMPT]\n" + prompt + "\n")
 
-    # Ask the user to enter the SQL query produced by the LLM
-    user_sql = input("Enter the SQL query to execute:\nSQL> ").strip()
+    try:
+        generated_sql = agent.generate(schema_for_prompt, question, db_type="sqlite")
+        print("[GENERATED SQL]\n" + generated_sql + "\n")
+    except Exception as exc:
+        print(f"Error generating SQL: {exc}")
+        db.close()
+        return
+
+    user_sql = input("Press Enter to run the generated query or paste another SQL:\nSQL> ").strip()
+    if not user_sql:
+        user_sql = generated_sql
 
     # Basic validation of the SQL statement
     if not sqlite3.complete_statement(user_sql):


### PR DESCRIPTION
## Summary
- add `SimpleAgent` that uses a multilingual FLAN-T5 model
- expose agent via `agent/__init__.py`
- use `SimpleAgent` in `main.py` to automatically produce SQL

## Testing
- `python -m py_compile src/agent/SimpleAgent.py src/main.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_6887eae1432c83338c41e472bc263c03