### PR TITLE
Update README with usage and credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,52 @@ The `docs` folder contains two PDF documents:
 - `MTI820_Proposition_de_Projet.pdf` – the original project proposal describing objectives and planning.
 - `MTI820_Revue_de_Litterature.pdf` – a literature review on using large language models for BI assistance.
 
+## Usage
+
+### Training
+
+Fine‑tune the multilingual model on the French Spider dataset:
+
+```bash
+python src/agent/train.py
+```
+
+Adapters and tokenizer files will be saved in the `adapters/` directory.
+
+### Interactive Demo
+
+Run the end‑to‑end pipeline that links a natural language question to a SQLite database and executes the generated query:
+
+```bash
+python src/main.py
+```
+
+This uses `database/sqlite/employee_db.sqlite` and stores past queries in `data/dialog_memory.txt`.
+
+### Evaluation
+
+Evaluate a trained model on a Spider‑FR style dataset:
+
+```bash
+python src/evaluation/pipeline_evaluator.py data/spider-fr/dev_spider.json --model adapters --db-root databases/spider/test_database
+```
+
+The script writes the predictions and an accuracy report in the current directory.
+
 ## Future Work
 
 Implementation of the training and inference pipeline is planned but not yet committed. The project schedule includes dataset preparation, fine‑tuning, evaluation, and reporting, as detailed in the project proposal.
+
+## Credits
+
+This project makes use of the following open source resources:
+
+- **Spider** dataset and evaluation tools from [taoyds/spider](https://github.com/taoyds/spider).  
+  Tao Yu, Rui Zhang, Kai Yang, Michihiro Yasunaga, Dongxu Wang, Zifan Li, James Ma, Irene Li, Qingning Yao, Shanelle Roman, Zilin Zhang and Dragomir Radev. *Spider: A Large-Scale Human-Labeled Dataset for Complex and Cross-Domain Semantic Parsing and Text-to-SQL Task*, 2019. <https://arxiv.org/abs/1809.08887>
+- **Test Suite Evaluation** code from [taoyds/test-suite-sql-eval](https://github.com/taoyds/test-suite-sql-eval).  
+  Ruiqi Zhong, Tao Yu and Dan Klein. *Semantic Evaluation for Text-to-SQL with Distilled Test Suites*, 2020. <https://arxiv.org/abs/2010.02840>
+- **Spider‑FR** dataset from [Marchanjo/spider-fr](https://huggingface.co/datasets/Marchanjo/spider-fr).  
+  Marcelo Archanjo Jose and Fabio Gagliardi Cozman. *A multilingual translator to SQL with database schema pruning to improve self-attention*, 2023. <https://doi.org/10.1007/s41870-023-01342-3>
 
 ## License
 


### PR DESCRIPTION
## Summary
- add instructions for training, demo and evaluation
- credit upstream Spider and Spider-FR datasets and evaluation code

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_6887f33a14008333a6569a84191d6022