### PR TITLE
Improve main demo loop

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,7 @@
 schema using ``DialogModule`` and producing a prompt for the future LLM agent."""
 
 from typing import List, Dict
+import os
 import sqlite3
 
 from DBManager import DBManager
@@ -9,7 +10,8 @@ from DialogModule import DialogModule
 from agent.PromptGenerator import generate_sql_prompt
 from agent.SimpleAgent import SimpleAgent
 
-DB_PATH = "database/sqlite/employee_db.sqlite"
+# Base path where Spider test databases are stored
+DB_BASE_PATH = "databases/spider/test_database"
 # File storing past user questions for the DialogModule
 MEMORY_FILE = "data/dialog_memory.txt"
 # Threshold used to decide whether we are confident enough in the
@@ -24,8 +26,19 @@ def compute_average(scores: List[float]) -> float:
 
 def main() -> None:
     """Run the end‑to‑end demo pipeline."""
-    
-    db = DBManager(DB_PATH)
+
+    mode = input(
+        "Select query generation mode - 'auto' to use the built-in agent or 'manual' to type the SQL yourself [auto/manual]: "
+    ).strip().lower()
+    auto_mode = mode != "manual"
+
+    db_id = input("Enter the database ID: ").strip()
+    db_path = os.path.join(DB_BASE_PATH, db_id, f"{db_id}.sqlite")
+    if not os.path.exists(db_path):
+        print(f"Database '{db_path}' not found.")
+        return
+
+    db = DBManager(db_path)
     schema_pairs: Dict[str, List[str]] = db.extract_column_table_pairs()
 
     # Flatten table and column names for the linker
@@ -35,84 +48,90 @@ def main() -> None:
 
     # Initialize the dialog helper which keeps a history of past questions
     dialog = DialogModule(schema_elements, MEMORY_FILE)
+    agent = SimpleAgent() if auto_mode else None
 
-    # Ask the user for a new question
-    question = dialog.ask()
+    while True:
+        # Ask the user for a new question
+        question = dialog.ask(prefix="Question (type 'exit' to quit): ")
+        if question.lower() in {"exit", "quit"}:
+            break
 
-    # Link the user's request to the database schema
-    matches = dialog.schema_link(question)
-    matches.sort(key=lambda m: m["score"], reverse=True)
+        # Link the user's request to the database schema
+        matches = dialog.schema_link(question)
+        matches.sort(key=lambda m: m["score"], reverse=True)
 
-    selected = []
-    selected_tables = []
-    for m in matches:
-        meta = m["schema_element"].split(" ")
-        if len(meta) > 1:
-            m["schema_table"] = meta[1]
-            m["schema_column"] = meta[0]
-        else:
-            m["schema_table"] = meta[0]
-        if m["schema_table"] not in selected_tables and m["score"] > CONFIDENCE_THRESHOLD:
-            selected.append(m)
-            selected_tables.append(m["schema_table"])
-        print(f"Matched: '{m['keyword']}' → '{m['schema_table']}.{m.get('schema_column',"")}' ({m['score']}%)")
-
-    avg_score = compute_average([m["score"] for m in selected])
-
-    if avg_score < CONFIDENCE_THRESHOLD:
-        # Confidence too low → ask for clarification
-        question += " " + dialog.ask(prompt="Could you clarify your question?", prefix="Clarification: ")
-
-    # Save the (possibly clarified) question for future runs
-    dialog.add_to_memory(question)
-
-    # Determine which tables were referenced
-    table_metadata = {t: db.extract_table_metadata(t) for t in selected_tables}
-
-    # Convert to the format expected by ContextGenerator
-    schema_for_prompt = {"tables": []}
-    for t, meta in table_metadata.items():
-        schema_for_prompt["tables"].append({
-            "name": t,
-            "columns": meta["columns"],
-        })
-
-    prompt = generate_sql_prompt(schema_for_prompt, question, db_type="sqlite")
-
-    agent = SimpleAgent()
-    print("\n[LLM PROMPT]\n" + prompt + "\n")
-
-    try:
-        generated_sql = agent.generate(schema_for_prompt, question, db_type="sqlite")
-        print("[GENERATED SQL]\n" + generated_sql + "\n")
-    except Exception as exc:
-        print(f"Error generating SQL: {exc}")
-        db.close()
-        return
-
-    user_sql = input("Press Enter to run the generated query or paste another SQL:\nSQL> ").strip()
-    if not user_sql:
-        user_sql = generated_sql
-
-    # Basic validation of the SQL statement
-    if not sqlite3.complete_statement(user_sql):
-        print("Invalid or incomplete SQL statement.")
-    else:
-        try:
-            result = db.execute_query(user_sql)
-            if "columns" in result:
-                header = " | ".join(result["columns"])
-                print(header)
-                print("-" * len(header))
-                for row in result["rows"]:
-                    print(" | ".join(str(v) for v in row))
+        selected = []
+        selected_tables = []
+        for m in matches:
+            meta = m["schema_element"].split(" ")
+            if len(meta) > 1:
+                m["schema_table"] = meta[1]
+                m["schema_column"] = meta[0]
             else:
-                print(f"Rows affected: {result['rowcount']}")
-        except Exception as exc:
-            print(f"Error executing query: {exc}")
+                m["schema_table"] = meta[0]
+            if m["schema_table"] not in selected_tables and m["score"] > CONFIDENCE_THRESHOLD:
+                selected.append(m)
+                selected_tables.append(m["schema_table"])
+            print(f"Matched: '{m['keyword']}' → '{m['schema_table']}.{m.get('schema_column', '')}' ({m['score']}%)")
+
+        avg_score = compute_average([m["score"] for m in selected])
+
+        if avg_score < CONFIDENCE_THRESHOLD:
+            # Confidence too low → ask for clarification
+            question += " " + dialog.ask(prompt="Could you clarify your question?", prefix="Clarification: ")
+
+        # Save the (possibly clarified) question for future runs
+        dialog.add_to_memory(question)
+
+        # Determine which tables were referenced
+        table_metadata = {t: db.extract_table_metadata(t) for t in selected_tables}
+
+        # Convert to the format expected by ContextGenerator
+        schema_for_prompt = {"tables": []}
+        for t, meta in table_metadata.items():
+            schema_for_prompt["tables"].append({
+                "name": t,
+                "columns": meta["columns"],
+            })
+
+        prompt = generate_sql_prompt(schema_for_prompt, question, db_type="sqlite")
+
+        print("\n[LLM PROMPT]\n" + prompt + "\n")
+
+        if auto_mode:
+            try:
+                generated_sql = agent.generate(schema_for_prompt, question, db_type="sqlite")
+                print("[GENERATED SQL]\n" + generated_sql + "\n")
+            except Exception as exc:
+                print(f"Error generating SQL: {exc}")
+                continue
+            user_sql = input("Press Enter to run the generated query or paste another SQL:\nSQL> ").strip()
+            if not user_sql:
+                user_sql = generated_sql
+        else:
+            user_sql = input("SQL> ").strip()
+            if not user_sql:
+                print("No SQL provided, skipping.")
+                continue
+
+        # Basic validation of the SQL statement
+        if not sqlite3.complete_statement(user_sql):
+            print("Invalid or incomplete SQL statement.")
+        else:
+            try:
+                result = db.execute_query(user_sql)
+                if "columns" in result:
+                    header = " | ".join(result["columns"])
+                    print(header)
+                    print("-" * len(header))
+                    for row in result["rows"]:
+                        print(" | ".join(str(v) for v in row))
+                else:
+                    print(f"Rows affected: {result['rowcount']}")
+            except Exception as exc:
+                print(f"Error executing query: {exc}")
 
     db.close()
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
## Summary
- add DB selection prompt and manual/auto SQL mode
- loop over questions until user exits

## Testing
- `python -m py_compile src/main.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_6887f069c934833399134ca4bb40ee23