### PR TITLE
Expose src API and spider package

### DIFF
--- a/spider/__init__.py
+++ b/spider/__init__.py
@@ -1,0 +1,6 @@
+"""Expose utilities from the original Spider toolkit."""
+
+from . import process_sql
+
+__all__ = ["process_sql"]
+

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,30 @@
+"""Convenience imports for the FR2SQL package.
+
+This module exposes the most commonly used classes and utilities so they
+can be imported directly from :mod:`src`.
+"""
+
+from .DBManager import DBManager
+from .DialogModule import DialogModule
+
+from .agent import (
+    SimpleAgent,
+    generate_sql_prompt,
+    SpiderFRDataset,
+    split_and_load,
+)
+
+from .evaluation import Evaluator, Picard, evaluate_dataset
+
+__all__ = [
+    "DBManager",
+    "DialogModule",
+    "SimpleAgent",
+    "generate_sql_prompt",
+    "SpiderFRDataset",
+    "split_and_load",
+    "Evaluator",
+    "Picard",
+    "evaluate_dataset",
+]
+

--- a/src/evaluation/__init__.py
+++ b/src/evaluation/__init__.py
@@ -1,0 +1,8 @@
+
+"""Expose evaluation utilities."""
+
+from .Evaluator import Evaluator
+from .Picard import Picard
+from .pipeline_evaluator import evaluate_dataset
+
+__all__ = ["Evaluator", "Picard", "evaluate_dataset"]


### PR DESCRIPTION
## Summary
- export core classes from `src` so they can be imported directly
- provide evaluation utilities through `src.evaluation`
- make `spider` a package exposing its `process_sql` module

## Testing
- `python -m py_compile src/__init__.py src/evaluation/__init__.py spider/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6888010b35908333b4ff24fd75437156