### PR TITLE
Utility to populate dialog memory

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ transformers
 tiktoken
 blobfile
 pyperclip
+tqdm

--- a/src/agent/__init__.py
+++ b/src/agent/__init__.py
@@ -1,10 +1,12 @@
 from .PromptGenerator import generate_sql_prompt
 from .SimpleAgent import SimpleAgent
 from .SpiderFRDataset import SpiderFRDataset, split_and_load
+from .populate_dialog_memory import populate_dialog_memory
 
 __all__ = [
     "generate_sql_prompt",
     "SimpleAgent",
     "SpiderFRDataset",
     "split_and_load",
+    "populate_dialog_memory",
 ]

--- a/src/agent/populate_dialog_memory.py
+++ b/src/agent/populate_dialog_memory.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import os
+from typing import Iterable
+
+from tqdm import tqdm
+
+from agent.SpiderFRDataset import SpiderFRDataset
+
+
+def populate_dialog_memory(
+    dataset: SpiderFRDataset,
+    db_root: str = "databases/spider/test_database",
+) -> None:
+    """Append each question to the dialog memory of its database."""
+
+    for question, db_id in tqdm(
+        zip(dataset.questions, dataset.db_ids), total=len(dataset.questions)
+    ):
+        memory_path = os.path.join(db_root, db_id, "dialog_memory.txt")
+        os.makedirs(os.path.dirname(memory_path), exist_ok=True)
+        with open(memory_path, "a", encoding="utf-8") as f:
+            f.write(question.strip() + "\n")
+
+
+if __name__ == "__main__":
+    ds = SpiderFRDataset()
+    populate_dialog_memory(ds)
+
+


### PR DESCRIPTION
## Summary
- add `populate_dialog_memory` helper to write questions from `SpiderFRDataset` into the correct database dialog memory files
- export the new helper from `agent` package
- include `tqdm` in requirements

## Testing
- `python -m py_compile src/agent/populate_dialog_memory.py`
- `python -m py_compile src/agent/__init__.py src/agent/SpiderFRDataset.py`

------
https://chatgpt.com/codex/tasks/task_e_6888159097188333bc9ca94eb35aac63